### PR TITLE
Add XHR Headers to be configured for tile requests

### DIFF
--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -14,7 +14,7 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     tileSize: 256,
     visibleLayers: null,
     buffer: 5,
-    authToken: null
+    xhrHeaders: {}
   },
   layers: {}, //Keep a list of the layers contained in the PBFs
   processedTiles: {}, //Keep a list of tiles that have been processed already
@@ -226,7 +226,10 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     };
 
     xhr.open('GET', src, true); //async is true
-    xhr.setRequestHeader("Authorization", self.options.authToken)
+    var headers = self.options.xhrHeaders;
+    for (var header in headers) {
+      xhr.setRequestHeader(header, headers[header]);
+    }
     xhr.responseType = 'arraybuffer';
     xhr.send();
   },

--- a/src/MVTSource.js
+++ b/src/MVTSource.js
@@ -13,7 +13,8 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     getIDForLayerFeature: function() {},
     tileSize: 256,
     visibleLayers: null,
-    buffer: 5
+    buffer: 5,
+    authToken: null
   },
   layers: {}, //Keep a list of the layers contained in the PBFs
   processedTiles: {}, //Keep a list of tiles that have been processed already
@@ -225,6 +226,7 @@ module.exports = L.TileLayer.MVTSource = L.TileLayer.Canvas.extend({
     };
 
     xhr.open('GET', src, true); //async is true
+    xhr.setRequestHeader("Authorization", self.options.authToken)
     xhr.responseType = 'arraybuffer';
     xhr.send();
   },


### PR DESCRIPTION
Adds a config point to set the Authorization header in the request for the vector tiles. This allows for an authenticated vector tile server.
